### PR TITLE
Fix Ghostty Windows blank pane and Shift+@ input

### DIFF
--- a/src/Devolutions.Terminal.App/Views/MainWindow.axaml.cs
+++ b/src/Devolutions.Terminal.App/Views/MainWindow.axaml.cs
@@ -4057,8 +4057,8 @@ public partial class MainWindow :
                         pane.Control.Engine.HistoryCount - (int)Math.Round(_scrollBar.Value));
                 }
             };
-            pane.Control.ViewportChanged += (_, _) => Update();
-            pane.Control.ScrollMarksChanged += (_, _) => Update();
+            pane.Control.ViewportChanged += (_, _) => PostUpdate();
+            pane.Control.ScrollMarksChanged += (_, _) => PostUpdate();
             PropertyChanged += (_, args) =>
             {
                 if (args.Property == BoundsProperty)
@@ -4067,6 +4067,17 @@ public partial class MainWindow :
                 }
             };
             Update();
+        }
+
+        private void PostUpdate()
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                Update();
+                return;
+            }
+
+            Dispatcher.UIThread.Post(Update);
         }
 
         private void Update()

--- a/src/Devolutions.Terminal.Control/KeyMapper.cs
+++ b/src/Devolutions.Terminal.Control/KeyMapper.cs
@@ -334,7 +334,7 @@ public static class KeyMapper
         _ => 0,
     };
 
-    private static string EncodeWin32(
+    private static string? EncodeWin32(
         Key key,
         KeyModifiers modifiers,
         string? keySymbol,
@@ -343,6 +343,11 @@ public static class KeyMapper
     {
         var virtualKey = VirtualKey(key);
         var unicode = TrySingleRune(keySymbol, out var rune) ? rune.Value : 0;
+        if (virtualKey == 0 && unicode == 0)
+        {
+            return null;
+        }
+
         var keyDown = eventType == TerminalKeyEventType.Release ? 0 : 1;
         var controlState =
             (modifiers.HasFlag(KeyModifiers.Shift) ? 0x10 : 0) |
@@ -373,6 +378,23 @@ public static class KeyMapper
         Key.PageUp => 0x21,
         Key.PageDown => 0x22,
         >= Key.F1 and <= Key.F12 => 0x70 + key - Key.F1,
+        Key.LeftShift or Key.RightShift => 0x10,
+        Key.LeftCtrl or Key.RightCtrl => 0x11,
+        Key.LeftAlt or Key.RightAlt => 0x12,
+        Key.LWin or Key.RWin => 0x5B,
+        Key.Space => 0x20,
+        Key.OemSemicolon => 0xBA,
+        Key.OemPlus => 0xBB,
+        Key.OemComma => 0xBC,
+        Key.OemMinus => 0xBD,
+        Key.OemPeriod => 0xBE,
+        Key.OemQuestion => 0xBF,
+        Key.OemTilde => 0xC0,
+        Key.OemOpenBrackets => 0xDB,
+        Key.OemPipe => 0xDC,
+        Key.OemCloseBrackets => 0xDD,
+        Key.OemQuotes => 0xDE,
+        Key.OemBackslash => 0xE2,
         _ => 0,
     };
 

--- a/src/Devolutions.Terminal.Control/TermControl.cs
+++ b/src/Devolutions.Terminal.Control/TermControl.cs
@@ -97,28 +97,17 @@ public sealed class TermControl : Avalonia.Controls.Control
 
         Engine.Invalidated += (_, _) =>
         {
-            if (_selection is not null &&
-                (_selectionCoordinateVersion != Engine.Buffer.CoordinateVersion ||
-                 _selectionAlternateBuffer != Engine.AlternateBufferActive))
-            {
-                SetSelection(null);
-            }
-
-            AccessibilityTextChanged?.Invoke(this, EventArgs.Empty);
-            ScrollMarksChanged?.Invoke(this, EventArgs.Empty);
-            ViewportChanged?.Invoke(this, EventArgs.Empty);
+            // Viewport/UIA listeners (scrollbar marks, automation peers) touch
+            // Avalonia controls and may snapshot history. That work must not
+            // run on the PTY thread or throw back into Engine.Feed — either
+            // kills ConPTY ReadLoop and leaves the constructor-sized blank grid.
             if (Dispatcher.UIThread.CheckAccess())
             {
-                _textInputMethodClient.NotifyCursorChanged();
-                InvalidateVisual();
+                HandleEngineInvalidated();
             }
             else
             {
-                Dispatcher.UIThread.Post(() =>
-                {
-                    _textInputMethodClient.NotifyCursorChanged();
-                    InvalidateVisual();
-                }, DispatcherPriority.Render);
+                Dispatcher.UIThread.Post(HandleEngineInvalidated, DispatcherPriority.Render);
             }
         };
         Engine.TitleChanged += (_, title) =>
@@ -233,6 +222,7 @@ public sealed class TermControl : Avalonia.Controls.Control
             CreateDefaultConnection();
         connection.OutputReceived += OnOutput;
         connection.SessionExited += OnSessionExited;
+        connection.Faulted += OnConnectionFaulted;
         _connection = connection;
         lock (_outputLock)
         {
@@ -256,6 +246,7 @@ public sealed class TermControl : Avalonia.Controls.Control
         {
             connection.OutputReceived -= OnOutput;
             connection.SessionExited -= OnSessionExited;
+            connection.Faulted -= OnConnectionFaulted;
             _connection = null;
             lock (_outputLock)
             {
@@ -310,6 +301,7 @@ public sealed class TermControl : Avalonia.Controls.Control
             _connection = null;
             connection.OutputReceived -= OnOutput;
             connection.SessionExited -= OnSessionExited;
+            connection.Faulted -= OnConnectionFaulted;
             lock (_outputLock)
             {
                 _acceptOutput = false;
@@ -919,7 +911,7 @@ public sealed class TermControl : Avalonia.Controls.Control
             frame,
             overlays,
             padding: 8,
-            drawCursor: _cursorOn && IsFocused));
+            drawCursor: Engine.CursorVisible && (_cursorOn || !IsFocused)));
     }
 
     public void SetSearchHighlights(IReadOnlyList<TerminalCellRange> highlights)
@@ -1253,11 +1245,44 @@ public sealed class TermControl : Avalonia.Controls.Control
                 return;
             }
 
-            // Feed on the PTY thread so cursor-position reports (CSI 6n) go
-            // back to zsh before PROMPT_SP prints a spurious '%'.
-            Engine.Feed(data.Span);
+            try
+            {
+                // Feed on the PTY thread so cursor-position reports (CSI 6n) go
+                // back to zsh before PROMPT_SP prints a spurious '%'.
+                Engine.Feed(data.Span);
+            }
+            catch (Exception exception)
+            {
+                ReportInteractionError("Terminal output", exception);
+            }
         }
     }
+
+    private void HandleEngineInvalidated()
+    {
+        try
+        {
+            if (_selection is not null &&
+                (_selectionCoordinateVersion != Engine.Buffer.CoordinateVersion ||
+                 _selectionAlternateBuffer != Engine.AlternateBufferActive))
+            {
+                SetSelection(null);
+            }
+
+            AccessibilityTextChanged?.Invoke(this, EventArgs.Empty);
+            ScrollMarksChanged?.Invoke(this, EventArgs.Empty);
+            ViewportChanged?.Invoke(this, EventArgs.Empty);
+            _textInputMethodClient.NotifyCursorChanged();
+            InvalidateVisual();
+        }
+        catch (Exception exception)
+        {
+            ReportInteractionError("Terminal output", exception);
+        }
+    }
+
+    private void OnConnectionFaulted(object? sender, Exception exception) =>
+        Dispatcher.UIThread.Post(() => ReportInteractionError("Terminal connection", exception));
 
     private void OnSessionExited(object? sender, TerminalExitInfo exit)
     {
@@ -1661,9 +1686,7 @@ public sealed class TermControl : Avalonia.Controls.Control
         }
         catch (Exception exception)
         {
-            InteractionError?.Invoke(
-                this,
-                new TerminalInteractionErrorEventArgs("OSC 52 clipboard write", exception));
+            ReportInteractionError("OSC 52 clipboard write", exception);
         }
     }
 
@@ -1948,9 +1971,13 @@ public sealed class TermControl : Avalonia.Controls.Control
         }
         catch (Exception exception)
         {
-            InteractionError?.Invoke(this, new TerminalInteractionErrorEventArgs(operation, exception));
+            ReportInteractionError(operation, exception);
         }
     }
+
+    private void ReportInteractionError(string operation, Exception exception) =>
+        InteractionError?.Invoke(this, new TerminalInteractionErrorEventArgs(operation, exception));
+
 
     internal static TerminalCursorStyle ParseCursorStyle(string? value) =>
         value is not null && value.Equals("underscore", StringComparison.OrdinalIgnoreCase)

--- a/src/Devolutions.Terminal.Ghostty/GhosttyTerminalEngine.cs
+++ b/src/Devolutions.Terminal.Ghostty/GhosttyTerminalEngine.cs
@@ -55,6 +55,14 @@ public sealed unsafe class GhosttyTerminalEngine : ITerminalEngine
     private readonly List<byte> _imageProbe = new(16);
     private ImageProbeState _imageProbeState;
     private bool _dcsImageCandidate;
+    private bool _ansiMode = true;
+    private int _modifyOtherKeys;
+    private KeyboardModeScanState _keyboardModeScan;
+    private byte _keyboardCsiPrivate;
+    private int _keyboardCsiValue;
+    private bool _keyboardCsiHasValue;
+    private readonly int[] _keyboardCsiParams = new int[8];
+    private int _keyboardCsiCount;
 
     private enum ImageProbeState : byte
     {
@@ -67,6 +75,13 @@ public sealed unsafe class GhosttyTerminalEngine : ITerminalEngine
         OscEscape,
         OscIgnored,
         OscIgnoredEscape,
+    }
+
+    private enum KeyboardModeScanState : byte
+    {
+        Ground,
+        Escape,
+        Csi,
     }
 
     public GhosttyTerminalEngine(int columns = 120, int rows = 30, int historySize = 9001)
@@ -162,7 +177,7 @@ public sealed unsafe class GhosttyTerminalEngine : ITerminalEngine
                 SynchronizeProjection();
             }
 
-            Invalidated?.Invoke(this, EventArgs.Empty);
+            RaiseInvalidated();
         }
     }
 
@@ -187,11 +202,11 @@ public sealed unsafe class GhosttyTerminalEngine : ITerminalEngine
     public bool InsertMode => QueryMode(4, ansi: true);
     public bool ReverseVideo => QueryMode(5);
     public TerminalInputMode InputMode => new(
-        AnsiMode: QueryMode(2),
+        AnsiMode: _ansiMode,
         ApplicationCursorKeys,
         ApplicationKeypad: QueryMode(66),
         KittyFlags: KittyKeyboardFlags.None,
-        ModifyOtherKeys: 0,
+        ModifyOtherKeys: _modifyOtherKeys,
         Win32InputMode: false);
     public int Columns => Buffer.Columns;
     public int Rows => Buffer.Rows;
@@ -218,6 +233,7 @@ public sealed unsafe class GhosttyTerminalEngine : ITerminalEngine
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
             ProbeUnsupportedImages(data);
+            TrackHostKeyboardModes(data);
             var trackedHistory = _historyAnchor is { IsInvalid: false, IsClosed: false };
             var historyBefore = ReadScrollbarCore().HistoryCount;
             fixed (byte* bytes = data)
@@ -252,7 +268,7 @@ public sealed unsafe class GhosttyTerminalEngine : ITerminalEngine
             }
         }
 
-        Invalidated?.Invoke(this, EventArgs.Empty);
+        RaiseInvalidated();
     }
 
     public void Feed(string text)
@@ -282,7 +298,7 @@ public sealed unsafe class GhosttyTerminalEngine : ITerminalEngine
             SynchronizeProjection();
         }
 
-        Invalidated?.Invoke(this, EventArgs.Empty);
+        RaiseInvalidated();
     }
 
     public void Reset()
@@ -291,11 +307,12 @@ public sealed unsafe class GhosttyTerminalEngine : ITerminalEngine
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
             GhosttyNative.TerminalReset(_terminal.DangerousGetHandle());
+            ResetHostKeyboardModes();
             SynchronizeProjection();
             ResetHistoryAnchor();
         }
 
-        Invalidated?.Invoke(this, EventArgs.Empty);
+        RaiseInvalidated();
     }
 
     public void SetScrollOffset(int offset)
@@ -315,7 +332,7 @@ public sealed unsafe class GhosttyTerminalEngine : ITerminalEngine
             SynchronizeProjection();
         }
 
-        Invalidated?.Invoke(this, EventArgs.Empty);
+        RaiseInvalidated();
     }
 
     public void ConfigureOptionalFeatures(
@@ -356,6 +373,117 @@ public sealed unsafe class GhosttyTerminalEngine : ITerminalEngine
         return BracketedPaste
             ? "\u001b[200~" + text.Replace("\u001b", string.Empty, StringComparison.Ordinal) + "\u001b[201~"
             : text;
+    }
+
+    private void ResetHostKeyboardModes()
+    {
+        _ansiMode = true;
+        _modifyOtherKeys = 0;
+        _keyboardModeScan = KeyboardModeScanState.Ground;
+        ResetKeyboardCsi();
+    }
+
+    private void ResetKeyboardCsi()
+    {
+        _keyboardCsiPrivate = 0;
+        _keyboardCsiValue = 0;
+        _keyboardCsiHasValue = false;
+        _keyboardCsiCount = 0;
+    }
+
+    private void TrackHostKeyboardModes(ReadOnlySpan<byte> data)
+    {
+        foreach (var value in data)
+        {
+            switch (_keyboardModeScan)
+            {
+                case KeyboardModeScanState.Ground:
+                    if (value == 0x1B)
+                    {
+                        _keyboardModeScan = KeyboardModeScanState.Escape;
+                    }
+                    break;
+                case KeyboardModeScanState.Escape:
+                    if (value == (byte)'[')
+                    {
+                        _keyboardModeScan = KeyboardModeScanState.Csi;
+                        ResetKeyboardCsi();
+                    }
+                    else
+                    {
+                        _keyboardModeScan = KeyboardModeScanState.Ground;
+                    }
+                    break;
+                case KeyboardModeScanState.Csi:
+                    if (value is 0x18 or 0x1A)
+                    {
+                        _keyboardModeScan = KeyboardModeScanState.Ground;
+                    }
+                    else if (_keyboardCsiPrivate == 0 &&
+                             !_keyboardCsiHasValue &&
+                             _keyboardCsiCount == 0 &&
+                             value is (byte)'?' or (byte)'>')
+                    {
+                        _keyboardCsiPrivate = value;
+                    }
+                    else if (value is >= (byte)'0' and <= (byte)'9')
+                    {
+                        _keyboardCsiHasValue = true;
+                        _keyboardCsiValue = _keyboardCsiValue > 100_000
+                            ? _keyboardCsiValue
+                            : (_keyboardCsiValue * 10) + (value - (byte)'0');
+                    }
+                    else if (value == (byte)';')
+                    {
+                        PushKeyboardCsiParam();
+                    }
+                    else if (value is >= 0x40 and <= 0x7E)
+                    {
+                        PushKeyboardCsiParam();
+                        ApplyKeyboardCsi(value);
+                        _keyboardModeScan = KeyboardModeScanState.Ground;
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void PushKeyboardCsiParam()
+    {
+        if (_keyboardCsiCount >= _keyboardCsiParams.Length)
+        {
+            _keyboardCsiHasValue = false;
+            _keyboardCsiValue = 0;
+            return;
+        }
+
+        _keyboardCsiParams[_keyboardCsiCount++] = _keyboardCsiHasValue ? _keyboardCsiValue : 0;
+        _keyboardCsiHasValue = false;
+        _keyboardCsiValue = 0;
+    }
+
+    private void ApplyKeyboardCsi(byte final)
+    {
+        if (_keyboardCsiPrivate == (byte)'?' && final is (byte)'h' or (byte)'l')
+        {
+            var enable = final == (byte)'h';
+            for (var index = 0; index < _keyboardCsiCount; index++)
+            {
+                switch (_keyboardCsiParams[index])
+                {
+                    case 2:
+                        _ansiMode = enable;
+                        break;
+                }
+            }
+        }
+        else if (_keyboardCsiPrivate == (byte)'>' && final == (byte)'m' &&
+                 _keyboardCsiCount > 0 && _keyboardCsiParams[0] == 4)
+        {
+            _modifyOtherKeys = _keyboardCsiCount > 1
+                ? Math.Clamp(_keyboardCsiParams[1], 0, 2)
+                : 0;
+        }
     }
 
     private void ProbeUnsupportedImages(ReadOnlySpan<byte> data)
@@ -1081,6 +1209,18 @@ public sealed unsafe class GhosttyTerminalEngine : ITerminalEngine
         G = (byte)(color >> 8),
         B = (byte)color,
     };
+
+    private void RaiseInvalidated()
+    {
+        try
+        {
+            Invalidated?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception)
+        {
+            // Subscribers (scrollbar, UIA) must not fail the PTY output pump.
+        }
+    }
 
     private static void ThrowIfFailed(GhosttyResult result, string operation)
     {

--- a/src/Devolutions.Terminal.Settings/SettingsService.cs
+++ b/src/Devolutions.Terminal.Settings/SettingsService.cs
@@ -10,8 +10,21 @@ public static class SettingsService
     public static string SettingsDirectory => ResolveSettingsDirectory();
     public static string StateDirectory => ResolveStateDirectory();
 
-    public static string SettingsPath =>
-        SettingsPathOverride ?? Path.Combine(SettingsDirectory, "settings.json");
+    public static string SettingsPath
+    {
+        get
+        {
+            var overridePath = SettingsPathOverride;
+            if (string.IsNullOrWhiteSpace(overridePath))
+            {
+                return Path.Combine(SettingsDirectory, "settings.json");
+            }
+
+            return Directory.Exists(overridePath)
+                ? Path.Combine(overridePath, "settings.json")
+                : overridePath;
+        }
+    }
 
     public static string StatePath =>
         SettingsPathOverride is { Length: > 0 }

--- a/tests/Devolutions.Terminal.Control.Tests/KeyMapperTests.cs
+++ b/tests/Devolutions.Terminal.Control.Tests/KeyMapperTests.cs
@@ -265,4 +265,20 @@ public sealed class KeyMapperTests
         Assert.Equal("\u001b[27;5;97~", modified);
         Assert.Equal("\u001b[65;0;97;0;8;2_", win32Release);
     }
+
+    [Fact]
+    public void Win32ShiftLetterUsesShiftVkThenCharacter()
+    {
+        var win32 = new TerminalInputMode(true, false, false, KittyKeyboardFlags.None, 0, true);
+
+        Assert.Equal(
+            "\u001b[16;0;0;1;16;1_",
+            KeyMapper.ToVt(Key.LeftShift, KeyModifiers.Shift, PhysicalKey.ShiftLeft, null, win32));
+        Assert.Equal(
+            "\u001b[68;0;68;1;16;1_",
+            KeyMapper.ToVt(Key.D, KeyModifiers.Shift, PhysicalKey.D, "D", win32));
+        Assert.Equal(
+            "\u001b[186;0;58;1;16;1_",
+            KeyMapper.ToVt(Key.OemSemicolon, KeyModifiers.Shift, PhysicalKey.Semicolon, ":", win32));
+    }
 }

--- a/tests/Devolutions.Terminal.Control.Tests/TermControlOutputPumpTests.cs
+++ b/tests/Devolutions.Terminal.Control.Tests/TermControlOutputPumpTests.cs
@@ -1,0 +1,118 @@
+using System.Text;
+using Avalonia.Headless.XUnit;
+using Devolutions.Terminal.Connection;
+using Devolutions.Terminal.Settings;
+using Xunit;
+
+namespace Devolutions.Terminal.Control.Tests;
+
+public sealed class TermControlOutputPumpTests
+{
+    [AvaloniaFact]
+    public async Task OutputPumpKeepsFeedingWhenViewportListenersThrow()
+    {
+        var connection = new FakePtyConnection();
+        var control = new TermControl();
+        control.ConnectionFactory = _ => connection;
+        control.ViewportChanged += (_, _) => throw new InvalidOperationException("scrollbar");
+
+        try
+        {
+            await control.StartAsync(new ProfileSettings { Commandline = "cmd.exe" }, 80, 24);
+            await Task.Run(() =>
+            {
+                connection.Emit("hello");
+                connection.Emit(" world");
+            });
+
+            var line = string.Concat(
+                control.Engine.CreateSnapshot().Buffer.Lines[0].Cells.Select(static cell => cell.Text));
+            Assert.Contains("hello world", line, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await control.CloseAsync();
+        }
+    }
+
+    private sealed class FakePtyConnection : IRestartableTerminalConnection
+    {
+        public event EventHandler<ReadOnlyMemory<byte>>? OutputReceived;
+#pragma warning disable CS0067
+        public event EventHandler<int>? Exited;
+        public event EventHandler<Exception>? Faulted;
+        public event EventHandler<TerminalExitInfo>? SessionExited;
+#pragma warning restore CS0067
+
+        public bool IsRunning { get; private set; }
+        public int Columns { get; private set; }
+        public int Rows { get; private set; }
+        public TerminalConnectionCapabilities Capabilities => TerminalConnectionCapabilities.Resize;
+        public TerminalConnectionState State { get; private set; }
+        public TerminalProcessMetadata? ProcessMetadata => null;
+        public TerminalExitInfo? LastExitInfo => null;
+
+        public Task StartAsync(
+            TerminalLaunchOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            Columns = options.Columns;
+            Rows = options.Rows;
+            IsRunning = true;
+            State = TerminalConnectionState.Connected;
+            return Task.CompletedTask;
+        }
+
+        public Task StartAsync(
+            string commandLine,
+            string? workingDirectory,
+            int columns,
+            int rows,
+            CancellationToken cancellationToken = default) =>
+            StartAsync(
+                new TerminalLaunchOptions
+                {
+                    CommandLine = commandLine,
+                    WorkingDirectory = workingDirectory,
+                    Columns = columns,
+                    Rows = rows,
+                },
+                cancellationToken);
+
+        public void Write(ReadOnlySpan<byte> data)
+        {
+        }
+
+        public void Write(string text)
+        {
+        }
+
+        public ValueTask WriteAsync(
+            ReadOnlyMemory<byte> data,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.CompletedTask;
+
+        public void Resize(int columns, int rows)
+        {
+            Columns = columns;
+            Rows = rows;
+        }
+
+        public Task RestartAsync(
+            TerminalLaunchOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task CloseAsync(CancellationToken cancellationToken = default)
+        {
+            IsRunning = false;
+            State = TerminalConnectionState.Closed;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public void Emit(string text) =>
+            OutputReceived?.Invoke(this, Encoding.UTF8.GetBytes(text));
+    }
+}

--- a/tests/Devolutions.Terminal.Ghostty.Tests/Devolutions.Terminal.Ghostty.Tests.csproj
+++ b/tests/Devolutions.Terminal.Ghostty.Tests/Devolutions.Terminal.Ghostty.Tests.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Devolutions.Terminal.Ghostty\Devolutions.Terminal.Ghostty.csproj" />
     <ProjectReference Include="..\..\src\Devolutions.Terminal.Control\Devolutions.Terminal.Control.csproj" />
+    <ProjectReference Include="..\..\src\Devolutions.Terminal.Connection\Devolutions.Terminal.Connection.csproj" />
   </ItemGroup>
   <Import Project="..\..\native\NativeLibraries.targets" />
 </Project>

--- a/tests/Devolutions.Terminal.Ghostty.Tests/GhosttyConPtyIntegrationTests.cs
+++ b/tests/Devolutions.Terminal.Ghostty.Tests/GhosttyConPtyIntegrationTests.cs
@@ -1,0 +1,338 @@
+using System.Runtime.Versioning;
+using System.Text;
+using Devolutions.Terminal.Connection;
+using Devolutions.Terminal.Core;
+using Xunit;
+
+namespace Devolutions.Terminal.Ghostty.Tests;
+
+[SupportedOSPlatform("windows")]
+public sealed class GhosttyConPtyIntegrationTests
+{
+    public static bool IsWindows => OperatingSystem.IsWindows();
+
+    [Fact(Skip = "ConPTY is Windows-only.", SkipUnless = nameof(IsWindows))]
+    public async Task CmdEchoProjectsIntoGhosttyGrid()
+    {
+        var marker = "GHOSTTY_CONPTY_OK";
+        await AssertGhosttyProjectsConPtyAsync(
+            EchoCommand(marker),
+            writeCommands: [],
+            marker,
+            TestContext.Current.CancellationToken);
+    }
+
+    [Fact(Skip = "ConPTY is Windows-only.", SkipUnless = nameof(IsWindows))]
+    public async Task WindowsPowerShellMarkerProjectsIntoGhosttyGrid()
+    {
+        var marker = "GHOSTTY_PS_OK";
+        await AssertGhosttyProjectsConPtyAsync(
+            WindowsPowerShellCommand("-NoLogo -NoProfile"),
+            writeCommands: ["Write-Output ([string]::Concat('GHOSTTY','_PS_OK'))\r"],
+            marker,
+            TestContext.Current.CancellationToken);
+    }
+
+    [Fact(Skip = "ConPTY is Windows-only.", SkipUnless = nameof(IsWindows))]
+    public async Task WindowsPowerShellWithProfileProjectsPrompt()
+    {
+        await AssertGhosttyProjectsConPtyAsync(
+            WindowsPowerShellCommand(string.Empty),
+            writeCommands: [],
+            "PS ",
+            TestContext.Current.CancellationToken);
+    }
+
+    [Fact(Skip = "ConPTY is Windows-only.", SkipUnless = nameof(IsWindows))]
+    public async Task ReplayOfPowerShellStartupBytesProjectsIntoGhosttyGrid()
+    {
+        var marker = "GHOSTTY_REPLAY_OK";
+        var captured = await CaptureConPtyBytesAsync(
+            WindowsPowerShellCommand("-NoLogo -NoProfile"),
+            writeCommands: ["Write-Output ([string]::Concat('GHOSTTY','_REPLAY_OK'))\r", "exit\r"],
+            marker,
+            TestContext.Current.CancellationToken);
+
+        using var ghostty = new GhosttyTerminalEngine(80, 24);
+        using var builtIn = new TerminalEngine(80, 24);
+        Exception? feedError = null;
+        try
+        {
+            ghostty.Feed(captured);
+            builtIn.Feed(captured);
+        }
+        catch (Exception ex)
+        {
+            feedError = ex;
+        }
+
+        AssertProjectionContains(
+            marker,
+            captured,
+            ghostty,
+            builtIn,
+            feedError,
+            responseCount: 0);
+    }
+
+    private static async Task AssertGhosttyProjectsConPtyAsync(
+        string commandLine,
+        string[] writeCommands,
+        string marker,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new ConPtyConnection();
+        using var ghostty = new GhosttyTerminalEngine(80, 24);
+        using var builtIn = new TerminalEngine(80, 24);
+        var captured = new List<byte>();
+        var responses = new List<byte[]>();
+        Exception? feedError = null;
+        var gate = new object();
+
+        ghostty.Invalidated += (_, _) => ghostty.CreateSnapshot(includeHistory: true);
+        ghostty.ResponseReady += (_, data) =>
+        {
+            lock (gate)
+            {
+                responses.Add(data);
+            }
+
+            try
+            {
+                connection.Write(data);
+            }
+            catch (Exception ex)
+            {
+                lock (gate)
+                {
+                    feedError ??= ex;
+                }
+            }
+        };
+        connection.OutputReceived += (_, data) =>
+        {
+            try
+            {
+                lock (gate)
+                {
+                    if (feedError is not null)
+                    {
+                        captured.AddRange(data.Span.ToArray());
+                        return;
+                    }
+                }
+
+                ghostty.Feed(data.Span);
+                builtIn.Feed(data.Span);
+            }
+            catch (Exception ex)
+            {
+                lock (gate)
+                {
+                    feedError ??= ex;
+                }
+            }
+
+            lock (gate)
+            {
+                captured.AddRange(data.Span.ToArray());
+            }
+        };
+
+        await connection.StartAsync(commandLine, null, 80, 24, cancellationToken);
+        foreach (var command in writeCommands)
+        {
+            connection.Write(command);
+        }
+
+        await WaitForAsync(
+            () =>
+            {
+                lock (gate)
+                {
+                    return Encoding.UTF8.GetString([.. captured]).Contains(marker, StringComparison.Ordinal);
+                }
+            },
+            TimeSpan.FromSeconds(15),
+            () =>
+            {
+                lock (gate)
+                {
+                    return Encoding.UTF8.GetString([.. captured]);
+                }
+            },
+            cancellationToken);
+
+        byte[] snapshot;
+        lock (captured)
+        {
+            snapshot = [.. captured];
+        }
+
+        AssertProjectionContains(
+            marker,
+            snapshot,
+            ghostty,
+            builtIn,
+            feedError,
+            responses.Count);
+    }
+
+    private static async Task<byte[]> CaptureConPtyBytesAsync(
+        string commandLine,
+        string[] writeCommands,
+        string marker,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new ConPtyConnection();
+        var captured = new List<byte>();
+        var exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.OutputReceived += (_, data) =>
+        {
+            lock (captured)
+            {
+                captured.AddRange(data.Span.ToArray());
+            }
+        };
+        connection.Exited += (_, code) => exited.TrySetResult(code);
+
+        await connection.StartAsync(commandLine, null, 80, 24, cancellationToken);
+        foreach (var command in writeCommands)
+        {
+            connection.Write(command);
+        }
+
+        await WaitForAsync(
+            () =>
+            {
+                lock (captured)
+                {
+                    return Encoding.UTF8.GetString([.. captured]).Contains(marker, StringComparison.Ordinal);
+                }
+            },
+            TimeSpan.FromSeconds(15),
+            () =>
+            {
+                lock (captured)
+                {
+                    return Encoding.UTF8.GetString([.. captured]);
+                }
+            },
+            cancellationToken);
+        _ = await exited.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+        lock (captured)
+        {
+            return [.. captured];
+        }
+    }
+
+    private static void AssertProjectionContains(
+        string marker,
+        byte[] captured,
+        GhosttyTerminalEngine ghostty,
+        TerminalEngine builtIn,
+        Exception? feedError,
+        int responseCount)
+    {
+        var raw = Encoding.UTF8.GetString(captured);
+        var ghosttyText = ViewportText(ghostty);
+        var builtInText = ViewportText(builtIn);
+        var detail =
+            $"feedError={feedError}\n" +
+            $"responses={responseCount}\n" +
+            $"rawChars={raw.Length} rawNonWs={CountNonWhitespace(raw)}\n" +
+            $"ghosttyNonWs={CountNonWhitespace(ghosttyText)} builtinNonWs={CountNonWhitespace(builtInText)}\n" +
+            $"ghostty={FormatViewport(ghosttyText)}\n" +
+            $"builtin={FormatViewport(builtInText)}\n" +
+            $"rawHead={FormatRawHead(captured)}";
+
+        Assert.True(feedError is null, detail);
+        Assert.Contains(marker, raw, StringComparison.Ordinal);
+        Assert.True(CountNonWhitespace(ghosttyText) > 0, detail);
+        Assert.True(
+            ghosttyText.Contains(marker, StringComparison.Ordinal) ||
+            Compact(ghosttyText).Contains(Compact(marker), StringComparison.Ordinal),
+            detail);
+        Assert.True(
+            builtInText.Contains(marker, StringComparison.Ordinal) ||
+            Compact(builtInText).Contains(Compact(marker), StringComparison.Ordinal),
+            detail);
+    }
+
+    private static async Task WaitForAsync(
+        Func<bool> condition,
+        TimeSpan timeout,
+        Func<string> snapshot,
+        CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(25, cancellationToken);
+        }
+
+        Assert.Fail($"Timed out waiting for ConPTY output. snapshot={FormatViewport(snapshot())}");
+    }
+
+    private static string ViewportText(ITerminalEngine engine)
+    {
+        var snapshot = engine.CreateSnapshot().Buffer;
+        var builder = new StringBuilder();
+        for (var row = 0; row < snapshot.Rows; row++)
+        {
+            foreach (var cell in snapshot.Lines[row].Cells)
+            {
+                builder.Append(cell.Text);
+            }
+
+            builder.Append('\n');
+        }
+
+        return builder.ToString();
+    }
+
+    private static int CountNonWhitespace(string text) =>
+        text.Count(static value => !char.IsWhiteSpace(value));
+
+    private static string Compact(string text) =>
+        string.Concat(text.Where(static value => !char.IsWhiteSpace(value)));
+
+    private static string FormatViewport(string text)
+    {
+        var trimmed = text.TrimEnd();
+        if (trimmed.Length > 400)
+        {
+            trimmed = trimmed[..400] + "…";
+        }
+
+        return trimmed.Replace("\n", "\\n").Replace("\r", "\\r");
+    }
+
+    private static string FormatRawHead(byte[] captured)
+    {
+        var length = Math.Min(captured.Length, 160);
+        return Convert.ToHexString(captured.AsSpan(0, length));
+    }
+
+    private static string EchoCommand(string value)
+    {
+        var comSpec = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe";
+        return $"\"{comSpec}\" /d /s /c \"echo {value}\"";
+    }
+
+    private static string WindowsPowerShellCommand(string arguments)
+    {
+        var powershell = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "WindowsPowerShell",
+            "v1.0",
+            "powershell.exe");
+        return $"\"{powershell}\" {arguments}";
+    }
+}

--- a/tests/Devolutions.Terminal.Ghostty.Tests/GhosttyTerminalEngineTests.cs
+++ b/tests/Devolutions.Terminal.Ghostty.Tests/GhosttyTerminalEngineTests.cs
@@ -133,6 +133,55 @@ public sealed class GhosttyTerminalEngineTests
     }
 
     [Fact]
+    public void HistorySnapshotFromInvalidatedDoesNotClearViewport()
+    {
+        using var engine = new GhosttyTerminalEngine(120, 30);
+        engine.Invalidated += (_, _) => engine.CreateSnapshot(includeHistory: true);
+
+        engine.Feed("hello Ghostty");
+
+        Assert.Equal("hello Ghostty", LineText(engine.CreateSnapshot().Buffer, 0));
+    }
+
+    [Fact]
+    public void InvalidatedSubscriberExceptionDoesNotFailFeed()
+    {
+        using var engine = new GhosttyTerminalEngine(20, 3);
+        engine.Invalidated += (_, _) => throw new InvalidOperationException("scrollbar");
+
+        engine.Feed("still projected");
+
+        Assert.Equal("still projected", LineText(engine.CreateSnapshot().Buffer, 0));
+    }
+
+    [Fact]
+    public void DefaultKeyboardModeIsAnsiNotVt52()
+    {
+        using var engine = new GhosttyTerminalEngine();
+
+        Assert.True(engine.InputMode.AnsiMode);
+        Assert.False(engine.InputMode.Win32InputMode);
+        Assert.Equal(0, engine.InputMode.ModifyOtherKeys);
+    }
+
+    [Fact]
+    public void ConPtyWin32InputRequestDoesNotSwitchGhosttyToWin32Encoding()
+    {
+        using var builtIn = new TerminalEngine(80, 24);
+        using var ghostty = new GhosttyTerminalEngine(80, 24);
+        const string conptyKeyboardModes = "\u001b[?9001h\u001b[?1004h\u001b[?25l";
+
+        builtIn.Feed(conptyKeyboardModes);
+        ghostty.Feed(conptyKeyboardModes);
+
+        Assert.True(builtIn.InputMode.Win32InputMode);
+        Assert.True(ghostty.InputMode.AnsiMode);
+        Assert.False(ghostty.InputMode.Win32InputMode);
+        Assert.Null(
+            KeyMapper.ToVt(Key.D, KeyModifiers.Shift, PhysicalKey.D, "D", ghostty.InputMode));
+    }
+
+    [Fact]
     public void FeedProjectsGhosttyGridIntoSharedBuffer()
     {
         using var engine = new GhosttyTerminalEngine(20, 3);


### PR DESCRIPTION
## Summary

Ghostty on Windows showed a black pane, and shifted keys (`D:`) inserted a green `@`. Both came from the ConPTY ↔ engine ↔ UI path, not from `ghostty-vt` failing to parse VT.

## What landed

- **Blank pane:** `TermControl` raised `ViewportChanged` on the PTY thread. The scrollbar then touched Avalonia / Ghostty history snapshots, which killed `ConPtyConnection.ReadLoop` and left the empty 120×30 grid. Invalidate/UIA/scrollbar work is marshaled to the UI thread; `Feed` errors and `Faulted` are surfaced instead of stopping the pump.
- **Ghostty keyboard modes:** libghostty does not expose DECANM/`CSI ?9001h`. Ghostty now defaults to ANSI and does **not** switch `KeyMapper` into incomplete Win32 encoding (capability is still off).
- **`@` before capitals:** When Win32 input *is* on (builtin + PSReadLine), Shift was encoded as `CSI 0;0;0;1;16;1_` (VK 0). Map Shift/Ctrl/Alt/OEM VKs and skip VK 0 with no unicode.
- **`DTERM_SETTINGS_PATH`:** A directory is treated as `settings.json` in that folder, so isolated Ghostty settings actually load.

## Validation

- Ghostty tests (including ConPTY integration) and Control KeyMapper/output-pump tests
- Live Ghostty session: UIA prompt text, then `cd D:` / `A` with no `@`

## Test plan

- [ ] `dotnet test tests/Devolutions.Terminal.Ghostty.Tests -p:SkipNativeRestore=true`
- [ ] `dotnet test tests/Devolutions.Terminal.Control.Tests`
- [ ] Launch with `"experimental.terminalEngine": "ghostty"` and confirm the shell prompt is visible
- [ ] In pwsh/PSReadLine, type `cd D:\` and confirm no `@` before `D` or `:`
- [ ] Builtin engine still accepts ConPTY `CSI ?9001h` and types shifted letters correctly