### PR TITLE
feat: add GitHub Release publication flow

### DIFF
--- a/.github/workflows/build-terminal.yml
+++ b/.github/workflows/build-terminal.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches:
       - "**"
+    tags:
+      - "v*"
     paths-ignore:
       - ".github/workflows/build-ghostty.yml"
   pull_request:
     paths-ignore:
       - ".github/workflows/build-ghostty.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -407,3 +410,98 @@ jobs:
           name: DevolutionsTerminal-MSIX-unsigned
           path: artifacts/msix/packages
           if-no-files-found: error
+
+  release:
+    name: Publish GitHub release
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+    needs:
+      - build
+      - native-aot
+      - linux-managed
+      - macos-managed
+      - macos-native-aot
+      - linux-packages
+      - linux-arm64-hardware
+      - msix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_VERSION: 0.1.${{ github.run_number }}
+      MSIX_VERSION: 0.1.${{ github.run_number }}.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Download Windows unsigned MSIX
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: DevolutionsTerminal-MSIX-unsigned
+          path: artifacts/msix-packages
+
+      - name: Download Linux x64 packages
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: DevolutionsTerminal-linux-x64-packages
+          path: artifacts/linux-x64
+
+      - name: Download Linux arm64 packages
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: DevolutionsTerminal-linux-arm64-packages
+          path: artifacts/linux-arm64
+
+      - name: Download macOS package artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: DevolutionsTerminal-osx-arm64-packages
+          path: artifacts/macos-packages
+
+      - name: Decode Windows signing certificate
+        shell: pwsh
+        env:
+          WINDOWS_SIGNING_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
+          WINDOWS_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_SIGNING_CERTIFICATE_BASE64)) {
+            throw "WINDOWS_SIGNING_CERTIFICATE_BASE64 is required for release signing."
+          }
+          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_SIGNING_CERTIFICATE_PASSWORD)) {
+            throw "WINDOWS_SIGNING_CERTIFICATE_PASSWORD is required for release signing."
+          }
+
+          $path = Join-Path $env:RUNNER_TEMP "Devolutions.Terminal.Signing.pfx"
+          [IO.File]::WriteAllBytes($path, [Convert]::FromBase64String($env:WINDOWS_SIGNING_CERTIFICATE_BASE64))
+          "CERT_PATH=$path" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Sign Windows MSIX packages
+        shell: pwsh
+        env:
+          WINDOWS_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
+        run: |
+          ./src/Devolutions.Terminal.Package/Scripts/Sign-Packages.ps1 ./artifacts/msix-packages $env:CERT_PATH $env:MSIX_VERSION (ConvertTo-SecureString $env:WINDOWS_SIGNING_CERTIFICATE_PASSWORD -AsPlainText -Force)
+
+      - name: Stage release assets
+        shell: bash
+        run: |
+          mkdir -p artifacts/release
+          cp -f artifacts/msix-packages/* artifacts/release/
+          cp -f artifacts/linux-x64/* artifacts/release/
+          cp -f artifacts/linux-arm64/* artifacts/release/
+          cp -f artifacts/macos-packages/* artifacts/release/
+          ls -1 artifacts/release
+
+      - name: Publish release to GitHub Releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh release view "v${RELEASE_VERSION}" >/dev/null 2>&1 || \
+            gh release create "v${RELEASE_VERSION}" \
+              --title "Devolutions Terminal ${RELEASE_VERSION}" \
+              --generate-notes \
+              --target "${{ github.sha }}"
+          gh release upload "v${RELEASE_VERSION}" artifacts/release/* --clobber
+
+
+

--- a/.github/workflows/build-terminal.yml
+++ b/.github/workflows/build-terminal.yml
@@ -411,6 +411,41 @@ jobs:
           path: artifacts/msix/packages
           if-no-files-found: error
 
+  msi:
+    name: MSI packages
+    needs: native-aot
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Download x64 publish
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: DevolutionsTerminal-win-x64
+          path: artifacts/msi/layout/win-x64
+
+      - name: Download arm64 publish
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: DevolutionsTerminal-win-arm64
+          path: artifacts/msi/layout/win-arm64
+
+      - name: Build MSI packages
+        shell: pwsh
+        run: >
+          ./src/Devolutions.Terminal.Package/Scripts/Build-Msi.ps1
+          -SkipPublish
+          -OutputDirectory ./artifacts/msi
+          -Version "0.1.${{ github.run_number }}.0"
+
+      - name: Upload unsigned MSI artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: DevolutionsTerminal-MSI-unsigned
+          path: artifacts/msi/packages
+          if-no-files-found: error
+
   release:
     name: Publish GitHub release
     if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
@@ -423,6 +458,7 @@ jobs:
       - linux-packages
       - linux-arm64-hardware
       - msix
+      - msi
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -438,6 +474,12 @@ jobs:
         with:
           name: DevolutionsTerminal-MSIX-unsigned
           path: artifacts/msix-packages
+
+      - name: Download Windows unsigned MSI
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: DevolutionsTerminal-MSI-unsigned
+          path: artifacts/msi-packages
 
       - name: Download Linux x64 packages
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -457,35 +499,92 @@ jobs:
           name: DevolutionsTerminal-osx-arm64-packages
           path: artifacts/macos-packages
 
-      - name: Decode Windows signing certificate
+      - name: Install Linux psign-tool
         shell: pwsh
         env:
-          WINDOWS_SIGNING_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
-          WINDOWS_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_SIGNING_CERTIFICATE_BASE64)) {
-            throw "WINDOWS_SIGNING_CERTIFICATE_BASE64 is required for release signing."
-          }
-          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_SIGNING_CERTIFICATE_PASSWORD)) {
-            throw "WINDOWS_SIGNING_CERTIFICATE_PASSWORD is required for release signing."
+          $toolRoot = Join-Path $env:RUNNER_TEMP "psign-tool"
+          $extractRoot = Join-Path $toolRoot "expanded"
+          if (Test-Path -LiteralPath $toolRoot) {
+            Remove-Item -LiteralPath $toolRoot -Recurse -Force
           }
 
-          $path = Join-Path $env:RUNNER_TEMP "Devolutions.Terminal.Signing.pfx"
-          [IO.File]::WriteAllBytes($path, [Convert]::FromBase64String($env:WINDOWS_SIGNING_CERTIFICATE_BASE64))
-          "CERT_PATH=$path" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          New-Item -Path $extractRoot -ItemType Directory -Force | Out-Null
+          gh release download --repo Devolutions/psign --pattern "psign-tool-linux-x64.zip" --dir $toolRoot --clobber
 
-      - name: Sign Windows MSIX packages
+          $toolArchivePath = Join-Path $toolRoot "psign-tool-linux-x64.zip"
+          if (-not (Test-Path -LiteralPath $toolArchivePath -PathType Leaf)) {
+            throw "psign-tool archive was not found at $toolArchivePath"
+          }
+
+          Expand-Archive -Path $toolArchivePath -DestinationPath $extractRoot -Force
+          $toolPath = Join-Path $extractRoot "psign-tool"
+          if (-not (Test-Path -LiteralPath $toolPath -PathType Leaf)) {
+            throw "psign-tool executable was not found at $toolPath"
+          }
+
+          chmod +x $toolPath
+          $extractRoot | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & $toolPath --version
+
+      - name: Sign Windows packages with Azure Artifact Signing
         shell: pwsh
         env:
-          WINDOWS_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
+          ARTIFACT_SIGNING_ENDPOINT: ${{ secrets.ARTIFACT_SIGNING_ENDPOINT }}
+          ARTIFACT_SIGNING_ACCOUNT_NAME: ${{ secrets.ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          ARTIFACT_SIGNING_PROFILE_NAME: ${{ secrets.ARTIFACT_SIGNING_PROFILE_NAME }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          CODE_SIGNING_CLIENT_ID: ${{ secrets.CODE_SIGNING_CLIENT_ID }}
+          CODE_SIGNING_CLIENT_SECRET: ${{ secrets.CODE_SIGNING_CLIENT_SECRET }}
+          CODE_SIGNING_TIMESTAMP_SERVER: ${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}
         run: |
-          ./src/Devolutions.Terminal.Package/Scripts/Sign-Packages.ps1 ./artifacts/msix-packages $env:CERT_PATH $env:MSIX_VERSION (ConvertTo-SecureString $env:WINDOWS_SIGNING_CERTIFICATE_PASSWORD -AsPlainText -Force)
+          $required = @(
+            "ARTIFACT_SIGNING_ENDPOINT",
+            "ARTIFACT_SIGNING_ACCOUNT_NAME",
+            "ARTIFACT_SIGNING_PROFILE_NAME",
+            "AZURE_TENANT_ID",
+            "CODE_SIGNING_CLIENT_ID",
+            "CODE_SIGNING_CLIENT_SECRET"
+          )
+          $missing = @($required | Where-Object { [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_)) })
+          if ($missing.Count -gt 0) {
+            throw "Missing Azure Artifact Signing secrets: $($missing -join ', ')"
+          }
+
+          $timestampServer = $env:CODE_SIGNING_TIMESTAMP_SERVER
+          if ([string]::IsNullOrWhiteSpace($timestampServer)) {
+            $timestampServer = "http://timestamp.acs.microsoft.com/"
+          }
+
+          ./src/Devolutions.Terminal.Package/Scripts/Sign-Packages.ps1 `
+            -PackageDirectory ./artifacts/msix-packages `
+            -Version $env:MSIX_VERSION `
+            -ArtifactSigningEndpoint $env:ARTIFACT_SIGNING_ENDPOINT `
+            -ArtifactSigningAccountName $env:ARTIFACT_SIGNING_ACCOUNT_NAME `
+            -ArtifactSigningProfileName $env:ARTIFACT_SIGNING_PROFILE_NAME `
+            -AzureTenantId $env:AZURE_TENANT_ID `
+            -ClientId $env:CODE_SIGNING_CLIENT_ID `
+            -ClientSecret $env:CODE_SIGNING_CLIENT_SECRET `
+            -TimestampServer $timestampServer
+
+          ./src/Devolutions.Terminal.Package/Scripts/Sign-Packages.ps1 `
+            -PackageDirectory ./artifacts/msi-packages `
+            -Version $env:MSIX_VERSION `
+            -ArtifactSigningEndpoint $env:ARTIFACT_SIGNING_ENDPOINT `
+            -ArtifactSigningAccountName $env:ARTIFACT_SIGNING_ACCOUNT_NAME `
+            -ArtifactSigningProfileName $env:ARTIFACT_SIGNING_PROFILE_NAME `
+            -AzureTenantId $env:AZURE_TENANT_ID `
+            -ClientId $env:CODE_SIGNING_CLIENT_ID `
+            -ClientSecret $env:CODE_SIGNING_CLIENT_SECRET `
+            -TimestampServer $timestampServer
 
       - name: Stage release assets
         shell: bash
         run: |
           mkdir -p artifacts/release
           cp -f artifacts/msix-packages/* artifacts/release/
+          cp -f artifacts/msi-packages/* artifacts/release/
           cp -f artifacts/linux-x64/* artifacts/release/
           cp -f artifacts/linux-arm64/* artifacts/release/
           cp -f artifacts/macos-packages/* artifacts/release/

--- a/.github/workflows/build-terminal.yml
+++ b/.github/workflows/build-terminal.yml
@@ -388,7 +388,7 @@ jobs:
           name: DevolutionsTerminal-win-arm64
           path: artifacts/msix/layout/win-arm64
 
-      - name: Build unsigned MSIX packages and bundle
+      - name: Build unsigned MSIX packages
         shell: pwsh
         run: >
           ./src/Devolutions.Terminal.Package/Scripts/Build-Packages.ps1
@@ -401,7 +401,7 @@ jobs:
         run: >
           ./src/Devolutions.Terminal.Package/Scripts/Test-Packages.ps1
           -PackagePath (Get-ChildItem ./artifacts/msix/packages -File |
-          Where-Object Extension -In ".msix", ".msixbundle" |
+          Where-Object Extension -eq ".msix" |
           ForEach-Object FullName)
 
       - name: Upload unsigned MSIX artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ TestResults/
 *.msixbundle
 *.appx
 *.appxbundle
+src/Devolutions.Terminal.Installer/GeneratedProductComponents.wxs
 
 ## Local secrets / certs
 *.pfx

--- a/docs/release.md
+++ b/docs/release.md
@@ -178,12 +178,26 @@ Development signing:
 ```powershell
 $password = Read-Host "Certificate password" -AsSecureString
 .\src\Devolutions.Terminal.Package\Scripts\New-DevelopmentCertificate.ps1 `
-  -OutputDirectory .\artifacts\msix\certificates -Password $password
+  -OutputDirectory .\artifacts\msix\certificates
 .\src\Devolutions.Terminal.Package\Scripts\Sign-Packages.ps1 `
   -PackageDirectory .\artifacts\msix\packages `
   -CertificatePath .\artifacts\msix\certificates\Devolutions.Terminal.pfx `
-  -Password $password -Version 0.1.0.0
+  -Version 0.1.0.0
 ```
+
+## MSI
+
+Build a WiX-based MSI package for the same published Windows outputs:
+
+```powershell
+.\src\Devolutions.Terminal.Package\Scripts\Build-Msi.ps1 `
+  -Architectures x64,arm64 `
+  -Version 0.1.0.0 `
+  -OutputDirectory .\artifacts\msi
+```
+
+The MSI project is in `src/Devolutions.Terminal.Installer` and uses a fixed
+`UpgradeCode` with per-machine install scope under `ProgramFiles6432Folder`.
 
 Never commit PFX files, passwords, certificate private keys, or signed internal
 artifacts. CI produces unsigned packages unless a protected release environment
@@ -193,15 +207,31 @@ injects signing credentials.
 
 The release workflow in `.github/workflows/build-terminal.yml` publishes signed
 Windows packages and the corresponding platform bundles directly to GitHub
-Releases without staging them in OneDrive. The workflow is intended for tag-based
-releases and for manual dispatch. It expects these repository secrets:
+Releases without staging them in OneDrive. It builds unsigned MSIX and MSI
+packages for Windows x64 and ARM64, then signs them on the Linux release runner
+with Devolutions `psign-tool` and Azure Artifact Signing (Trusted Signing). The
+private key never lands on the runner. Signed Windows packages are uploaded
+alongside Linux and macOS archives. The workflow is intended for tag-based
+releases and for manual dispatch.
 
-- `WINDOWS_SIGNING_CERTIFICATE_BASE64`
-- `WINDOWS_SIGNING_CERTIFICATE_PASSWORD`
+Required secrets:
 
-The certificate is decoded to a temporary `.pfx`, passed to
-`src/Devolutions.Terminal.Package/Scripts/Sign-Packages.ps1`, and then the
-signed MSIX and platform archives are uploaded via `gh release upload`.
+- `ARTIFACT_SIGNING_ENDPOINT`
+- `ARTIFACT_SIGNING_ACCOUNT_NAME`
+- `ARTIFACT_SIGNING_PROFILE_NAME`
+- `AZURE_TENANT_ID`
+- `CODE_SIGNING_CLIENT_ID`
+- `CODE_SIGNING_CLIENT_SECRET`
+
+Optional repository variable:
+
+- `CODE_SIGNING_TIMESTAMP_SERVER` (defaults to `http://timestamp.acs.microsoft.com/`)
+
+`psign-tool` portable Artifact Signing can sign PE, MSI, and flat MSIX packages.
+It cannot sign `.msixbundle` containers, so GitHub Releases publish the signed
+per-architecture `.msix` files rather than a re-signed bundle. The MSIX
+`Publisher` identity in `Package.appxmanifest` must match the Artifact Signing
+certificate subject.
 
 ## Release gates
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -189,6 +189,20 @@ Never commit PFX files, passwords, certificate private keys, or signed internal
 artifacts. CI produces unsigned packages unless a protected release environment
 injects signing credentials.
 
+## GitHub Release automation
+
+The release workflow in `.github/workflows/build-terminal.yml` publishes signed
+Windows packages and the corresponding platform bundles directly to GitHub
+Releases without staging them in OneDrive. The workflow is intended for tag-based
+releases and for manual dispatch. It expects these repository secrets:
+
+- `WINDOWS_SIGNING_CERTIFICATE_BASE64`
+- `WINDOWS_SIGNING_CERTIFICATE_PASSWORD`
+
+The certificate is decoded to a temporary `.pfx`, passed to
+`src/Devolutions.Terminal.Package/Scripts/Sign-Packages.ps1`, and then the
+signed MSIX and platform archives are uploaded via `gh release upload`.
+
 ## Release gates
 
 1. Regenerate `compat/windows-terminal.json` and review inventory changes.

--- a/docs/release.md
+++ b/docs/release.md
@@ -163,12 +163,11 @@ whitespace while retaining unknown/local-layer data. Runtime state is stored in
 
 ## MSIX
 
-Create unsigned x64/ARM64 packages and a bundle:
+Create unsigned x64 and ARM64 packages:
 
 ```powershell
 .\src\Devolutions.Terminal.Package\Scripts\Build-Packages.ps1 -Version 0.1.0.0
-$packages = Get-ChildItem .\artifacts\msix\packages\*.msix,
-  .\artifacts\msix\packages\*.msixbundle
+$packages = Get-ChildItem .\artifacts\msix\packages\*.msix
 .\src\Devolutions.Terminal.Package\Scripts\Test-Packages.ps1 `
   -PackagePath $packages.FullName
 ```
@@ -206,13 +205,13 @@ injects signing credentials.
 ## GitHub Release automation
 
 The release workflow in `.github/workflows/build-terminal.yml` publishes signed
-Windows packages and the corresponding platform bundles directly to GitHub
-Releases without staging them in OneDrive. It builds unsigned MSIX and MSI
-packages for Windows x64 and ARM64, then signs them on the Linux release runner
-with Devolutions `psign-tool` and Azure Artifact Signing (Trusted Signing). The
-private key never lands on the runner. Signed Windows packages are uploaded
-alongside Linux and macOS archives. The workflow is intended for tag-based
-releases and for manual dispatch.
+Windows packages and the corresponding platform archives directly to GitHub
+Releases without staging them in OneDrive. It builds unsigned per-architecture
+MSIX and MSI packages for Windows x64 and ARM64, then signs them on the Linux
+release runner with Devolutions `psign-tool` and Azure Artifact Signing
+(Trusted Signing). The private key never lands on the runner. Signed Windows
+packages are uploaded alongside Linux and macOS archives. The workflow is
+intended for tag-based releases and for manual dispatch.
 
 Required secrets:
 
@@ -227,11 +226,9 @@ Optional repository variable:
 
 - `CODE_SIGNING_TIMESTAMP_SERVER` (defaults to `http://timestamp.acs.microsoft.com/`)
 
-`psign-tool` portable Artifact Signing can sign PE, MSI, and flat MSIX packages.
-It cannot sign `.msixbundle` containers, so GitHub Releases publish the signed
-per-architecture `.msix` files rather than a re-signed bundle. The MSIX
-`Publisher` identity in `Package.appxmanifest` must match the Artifact Signing
-certificate subject.
+`psign-tool` portable Artifact Signing signs the per-architecture `.msix` and
+`.msi` files. The MSIX `Publisher` identity in `Package.appxmanifest` must
+match the Artifact Signing certificate subject.
 
 ## Release gates
 
@@ -239,9 +236,8 @@ certificate subject.
 2. Run the full Release solution tests with no failures or unconditional skips.
 3. Publish and launch-smoke NativeAOT x64.
 4. Cross-publish NativeAOT ARM64.
-5. Build and structurally validate both MSIX packages and the bundle, including
-   shell-helper PE architecture, SHA-256 manifests, COM/Explorer extensions,
-   and notices.
+5. Build and structurally validate both MSIX packages, including shell-helper
+   PE architecture, SHA-256 manifests, COM/Explorer extensions, and notices.
 6. Sign and verify package publisher/identity/version in a protected environment.
 7. Install, launch `Devolutions.Terminal.exe`, invoke `dt.exe`, upgrade, and uninstall
    on clean x64 and ARM64 Windows VMs.

--- a/src/Devolutions.Terminal.Installer/Devolutions.Terminal.Installer.wixproj
+++ b/src/Devolutions.Terminal.Installer/Devolutions.Terminal.Installer.wixproj
@@ -1,0 +1,16 @@
+<Project Sdk="WixToolset.Sdk/4.0.2">
+  <PropertyGroup>
+    <OutputType>Package</OutputType>
+    <Name>Devolutions.Terminal</Name>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
+    <ProductVersion Condition="'$(ProductVersion)' == ''">0.1.0.0</ProductVersion>
+    <DefineConstants>ProductVersion=$(ProductVersion)</DefineConstants>
+    <OutputName>Devolutions.Terminal_$(ProductVersion)_$(Platform)</OutputName>
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <Target Name="GenerateProductComponents" BeforeTargets="Compile" Condition="'$(PublishDir)' != '' and Exists('$(PublishDir)')">
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)..\Devolutions.Terminal.Package\Scripts\Write-MsiComponents.ps1&quot; -PublishDir &quot;$(PublishDir)&quot; -OutputFile &quot;$(MSBuildThisFileDirectory)GeneratedProductComponents.wxs&quot;" />
+  </Target>
+</Project>

--- a/src/Devolutions.Terminal.Installer/Devolutions.Terminal.Installer.wixproj
+++ b/src/Devolutions.Terminal.Installer/Devolutions.Terminal.Installer.wixproj
@@ -9,8 +9,4 @@
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
-
-  <Target Name="GenerateProductComponents" BeforeTargets="Compile" Condition="'$(PublishDir)' != '' and Exists('$(PublishDir)')">
-    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)..\Devolutions.Terminal.Package\Scripts\Write-MsiComponents.ps1&quot; -PublishDir &quot;$(PublishDir)&quot; -OutputFile &quot;$(MSBuildThisFileDirectory)GeneratedProductComponents.wxs&quot;" />
-  </Target>
 </Project>

--- a/src/Devolutions.Terminal.Installer/Package.wxs
+++ b/src/Devolutions.Terminal.Installer/Package.wxs
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package
+      Name="Devolutions Terminal"
+      Manufacturer="Devolutions Inc."
+      Version="$(var.ProductVersion)"
+      UpgradeCode="{1B5D5A55-1C5A-48AA-ACD2-B1FEC7950FF8}"
+      Scope="perMachine"
+      Language="1033">
+    <MediaTemplate CompressionLevel="high" EmbedCab="yes" />
+
+    <Feature Id="MainFeature" Title="Devolutions Terminal" Level="1">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Package>
+
+  <Fragment>
+    <StandardDirectory Id="ProgramFiles6432Folder">
+      <Directory Id="INSTALLLOCATION" Name="Devolutions Terminal" />
+    </StandardDirectory>
+  </Fragment>
+</Wix>

--- a/src/Devolutions.Terminal.Package/README.md
+++ b/src/Devolutions.Terminal.Package/README.md
@@ -1,7 +1,7 @@
 # Devolutions Terminal MSIX packaging
 
 This project owns the development package identity and the scripts that turn the
-`win-x64` and `win-arm64` NativeAOT publishes into MSIX packages and a bundle.
+`win-x64` and `win-arm64` NativeAOT publishes into per-architecture MSIX packages.
 Direct `dotnet run` and `dotnet publish` remain unpackaged and do not require
 registration.
 
@@ -36,8 +36,7 @@ Install [winapp CLI](https://learn.microsoft.com/windows/apps/dev-tools/winapp-c
 ```powershell
 .\src\Devolutions.Terminal.Package\Scripts\Build-Packages.ps1
 .\src\Devolutions.Terminal.Package\Scripts\Test-Packages.ps1 `
-  -PackagePath .\artifacts\msix\packages\*.msix, `
-               .\artifacts\msix\packages\*.msixbundle
+  -PackagePath .\artifacts\msix\packages\*.msix
 ```
 
 Unsigned packages are the default so CI can publish artifacts for a trusted
@@ -60,7 +59,6 @@ $password = Read-Host "Certificate password" -AsSecureString
 .\src\Devolutions.Terminal.Package\Scripts\New-DevelopmentCertificate.ps1 `
   -Password $password
 
-# Rebuild the bundle from the newly signed architecture packages, then sign it.
 .\src\Devolutions.Terminal.Package\Scripts\Sign-Packages.ps1 `
   -PackageDirectory .\artifacts\msix\packages `
   -CertificatePath .\artifacts\msix\certificates\Devolutions.Terminal.pfx `
@@ -79,9 +77,9 @@ terminal:
 Install, launch, validate, and uninstall:
 
 ```powershell
-$bundle = ".\artifacts\msix\packages\Devolutions.Terminal_0.1.0.0_x64_arm64.msixbundle"
-.\src\Devolutions.Terminal.Package\Scripts\Test-Packages.ps1 -PackagePath $bundle -RequireSignature
-.\src\Devolutions.Terminal.Package\Scripts\Install-Package.ps1 -PackagePath $bundle -Launch
+$package = ".\artifacts\msix\packages\Devolutions.Terminal_0.1.0.0_x64.msix"
+.\src\Devolutions.Terminal.Package\Scripts\Test-Packages.ps1 -PackagePath $package -RequireSignature
+.\src\Devolutions.Terminal.Package\Scripts\Install-Package.ps1 -PackagePath $package -Launch
 dt.exe
 Start-Process "dterm:"
 .\src\Devolutions.Terminal.Package\Scripts\Uninstall-Package.ps1

--- a/src/Devolutions.Terminal.Package/Scripts/Build-Msi.ps1
+++ b/src/Devolutions.Terminal.Package/Scripts/Build-Msi.ps1
@@ -71,13 +71,22 @@ foreach ($architecture in $Architectures) {
     $buildDirectory = [IO.Path]::GetFullPath((Join-Path $packageOutput $architecture))
     New-Item -ItemType Directory -Force -Path $buildDirectory | Out-Null
 
+    $generatedComponents = Join-Path $dotnetRoot "src\Devolutions.Terminal.Installer\GeneratedProductComponents.wxs"
+    & (Join-Path $PSScriptRoot "Write-MsiComponents.ps1") -PublishDir $layout -OutputFile $generatedComponents
+    if ($LASTEXITCODE -ne 0) {
+        throw "Generating MSI component list failed with exit code $LASTEXITCODE."
+    }
+    if (-not (Test-Path -LiteralPath $generatedComponents -PathType Leaf)) {
+        throw "MSI component list was not written to '$generatedComponents'."
+    }
+
+    $platform = if ($architecture -eq "arm64") { "ARM64" } else { "x64" }
     Invoke-Checked -FilePath dotnet -ArgumentList @(
         "build",
         $installerProject,
         "-c", $Configuration,
-        "-p:Platform=$architecture",
+        "-p:Platform=$platform",
         "-p:ProductVersion=$Version",
-        "-p:PublishDir=$layout",
         "-p:OutputPath=$buildDirectory\\",
         "-p:OutputName=Devolutions.Terminal_${Version}_${architecture}"
     )

--- a/src/Devolutions.Terminal.Package/Scripts/Build-Msi.ps1
+++ b/src/Devolutions.Terminal.Package/Scripts/Build-Msi.ps1
@@ -73,9 +73,6 @@ foreach ($architecture in $Architectures) {
 
     $generatedComponents = Join-Path $dotnetRoot "src\Devolutions.Terminal.Installer\GeneratedProductComponents.wxs"
     & (Join-Path $PSScriptRoot "Write-MsiComponents.ps1") -PublishDir $layout -OutputFile $generatedComponents
-    if ($LASTEXITCODE -ne 0) {
-        throw "Generating MSI component list failed with exit code $LASTEXITCODE."
-    }
     if (-not (Test-Path -LiteralPath $generatedComponents -PathType Leaf)) {
         throw "MSI component list was not written to '$generatedComponents'."
     }

--- a/src/Devolutions.Terminal.Package/Scripts/Build-Msi.ps1
+++ b/src/Devolutions.Terminal.Package/Scripts/Build-Msi.ps1
@@ -1,0 +1,98 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("x64", "arm64")]
+    [string[]] $Architectures = @("x64", "arm64"),
+
+    [ValidatePattern("^\d{1,5}\.\d{1,5}\.\d{1,5}\.\d{1,5}$")]
+    [string] $Version = "0.1.0.0",
+
+    [ValidateSet("Debug", "Release")]
+    [string] $Configuration = "Release",
+
+    [string] $OutputDirectory,
+
+    [switch] $SkipPublish
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$packageRoot = Split-Path -Parent $PSScriptRoot
+$dotnetRoot = [IO.Path]::GetFullPath((Join-Path $packageRoot "..\.."))
+$hostProject = Join-Path $dotnetRoot "src\Devolutions.Terminal\Devolutions.Terminal.csproj"
+$installerProject = Join-Path $dotnetRoot "src\Devolutions.Terminal.Installer\Devolutions.Terminal.Installer.wixproj"
+
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+    $OutputDirectory = Join-Path $dotnetRoot "artifacts\msi"
+}
+
+$OutputDirectory = [IO.Path]::GetFullPath($OutputDirectory)
+$layoutRoot = Join-Path $OutputDirectory "layout"
+$packageOutput = Join-Path $OutputDirectory "packages"
+New-Item -ItemType Directory -Force -Path $layoutRoot, $packageOutput | Out-Null
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory)]
+        [string] $FilePath,
+
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]] $ArgumentList
+    )
+
+    & $FilePath @ArgumentList
+    if ($LASTEXITCODE -ne 0) {
+        throw "'$FilePath' failed with exit code $LASTEXITCODE."
+    }
+}
+
+foreach ($architecture in $Architectures) {
+    $runtimeIdentifier = "win-$architecture"
+    $layout = Join-Path $layoutRoot $runtimeIdentifier
+    if (-not $SkipPublish) {
+        if (Test-Path -LiteralPath $layout) {
+            Remove-Item -Recurse -Force -LiteralPath $layout
+        }
+
+        New-Item -ItemType Directory -Force -Path $layout | Out-Null
+        Invoke-Checked -FilePath dotnet -ArgumentList @(
+            "publish",
+            $hostProject,
+            "-c", $Configuration,
+            "-r", $runtimeIdentifier,
+            "--self-contained",
+            "-o", $layout
+        )
+    }
+    elseif (-not (Test-Path -LiteralPath (Join-Path $layout "Devolutions.Terminal.exe"))) {
+        throw "Published output for '$runtimeIdentifier' was not found at '$layout'."
+    }
+
+    $buildDirectory = [IO.Path]::GetFullPath((Join-Path $packageOutput $architecture))
+    New-Item -ItemType Directory -Force -Path $buildDirectory | Out-Null
+
+    Invoke-Checked -FilePath dotnet -ArgumentList @(
+        "build",
+        $installerProject,
+        "-c", $Configuration,
+        "-p:Platform=$architecture",
+        "-p:ProductVersion=$Version",
+        "-p:PublishDir=$layout",
+        "-p:OutputPath=$buildDirectory\\",
+        "-p:OutputName=Devolutions.Terminal_${Version}_${architecture}"
+    )
+
+    $generatedMsi = Join-Path $buildDirectory "Devolutions.Terminal_${Version}_${architecture}.msi"
+    if (-not (Test-Path -LiteralPath $generatedMsi -PathType Leaf)) {
+        $generatedMsi = (Get-ChildItem -LiteralPath $buildDirectory -Filter "*.msi" -File | Sort-Object Name | Select-Object -First 1).FullName
+    }
+
+    if (-not (Test-Path -LiteralPath $generatedMsi -PathType Leaf)) {
+        throw "No MSI artifact was created for '$runtimeIdentifier'."
+    }
+
+    Copy-Item -Force -LiteralPath $generatedMsi -Destination (Join-Path $packageOutput ([IO.Path]::GetFileName($generatedMsi)))
+}
+
+Get-ChildItem -LiteralPath $packageOutput -File -Filter "*.msi" |
+    Sort-Object Name

--- a/src/Devolutions.Terminal.Package/Scripts/Build-Packages.ps1
+++ b/src/Devolutions.Terminal.Package/Scripts/Build-Packages.ps1
@@ -15,8 +15,6 @@ param(
 
     [switch] $SkipNativeBuild,
 
-    [switch] $SkipBundle,
-
     [string] $CertificatePath,
 
     [securestring] $CertificatePassword
@@ -118,7 +116,6 @@ if (-not $SkipNativeBuild) {
 
 $plainTextPassword = Get-PlainText $CertificatePassword
 try {
-    $layouts = @()
     foreach ($architecture in $Architectures) {
         $runtimeIdentifier = "win-$architecture"
         $layout = Join-Path $layoutRoot $runtimeIdentifier
@@ -202,26 +199,6 @@ try {
         }
 
         Invoke-Checked -FilePath winapp -ArgumentList $arguments
-        $layouts += $layout
-    }
-
-    if (-not $SkipBundle -and $layouts.Count -gt 1) {
-        $architectureLabel = $Architectures -join "_"
-        $bundlePath = Join-Path $packageOutput "Devolutions.Terminal_${Version}_${architectureLabel}.msixbundle"
-        $arguments = @("package") + $layouts + @(
-            "--manifest", $versionedManifest,
-            "--output", $bundlePath,
-            "--skip-pri",
-            "--quiet"
-        )
-        if (-not [string]::IsNullOrWhiteSpace($CertificatePath)) {
-            $arguments += @("--cert", [IO.Path]::GetFullPath($CertificatePath))
-            if ($null -ne $plainTextPassword) {
-                $arguments += @("--cert-password", $plainTextPassword)
-            }
-        }
-
-        Invoke-Checked -FilePath winapp -ArgumentList $arguments
     }
 }
 finally {
@@ -229,5 +206,5 @@ finally {
 }
 
 Get-ChildItem -LiteralPath $packageOutput -File |
-    Where-Object Extension -In ".msix", ".msixbundle" |
+    Where-Object Extension -eq ".msix" |
     Sort-Object Name

--- a/src/Devolutions.Terminal.Package/Scripts/Sign-Packages.ps1
+++ b/src/Devolutions.Terminal.Package/Scripts/Sign-Packages.ps1
@@ -1,73 +1,228 @@
-[CmdletBinding()]
+[CmdletBinding(DefaultParameterSetName = "ArtifactSigning")]
 param(
     [Parameter(Mandatory)]
     [ValidateScript({ Test-Path -LiteralPath $_ -PathType Container })]
     [string] $PackageDirectory,
 
     [Parameter(Mandatory)]
-    [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
-    [string] $CertificatePath,
-
-    [Parameter(Mandatory)]
     [ValidatePattern("^\d{1,5}\.\d{1,5}\.\d{1,5}\.\d{1,5}$")]
     [string] $Version,
 
-    [securestring] $Password
+    [Parameter(ParameterSetName = "Certificate", Mandatory)]
+    [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
+    [string] $CertificatePath,
+
+    [Parameter(ParameterSetName = "Certificate")]
+    [securestring] $Password,
+
+    [Parameter(ParameterSetName = "ArtifactSigning", Mandatory)]
+    [string] $ArtifactSigningEndpoint,
+
+    [Parameter(ParameterSetName = "ArtifactSigning", Mandatory)]
+    [string] $ArtifactSigningAccountName,
+
+    [Parameter(ParameterSetName = "ArtifactSigning", Mandatory)]
+    [string] $ArtifactSigningProfileName,
+
+    [Parameter(ParameterSetName = "ArtifactSigning", Mandatory)]
+    [string] $AzureTenantId,
+
+    [Parameter(ParameterSetName = "ArtifactSigning", Mandatory)]
+    [string] $ClientId,
+
+    [Parameter(ParameterSetName = "ArtifactSigning", Mandatory)]
+    [string] $ClientSecret,
+
+    [Parameter(ParameterSetName = "ArtifactSigning")]
+    [string] $TimestampServer = "http://timestamp.acs.microsoft.com/",
+
+    [string] $PsignTool
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-if ($null -eq $Password) {
-    $Password = Read-Host "Signing certificate password" -AsSecureString
+$PackageDirectory = [IO.Path]::GetFullPath($PackageDirectory)
+$useArtifactSigning = $PSCmdlet.ParameterSetName -eq "ArtifactSigning"
+
+function Get-ExpectedPackages {
+    param(
+        [string[]] $Names
+    )
+
+    $matches = @()
+    foreach ($name in $Names) {
+        $path = Join-Path $PackageDirectory $name
+        if (Test-Path -LiteralPath $path -PathType Leaf) {
+            $matches += Get-Item -LiteralPath $path
+        }
+    }
+
+    return $matches
 }
 
-$PackageDirectory = [IO.Path]::GetFullPath($PackageDirectory)
-$CertificatePath = [IO.Path]::GetFullPath($CertificatePath)
-$expectedPackageNames = @(
+function Resolve-PsignTool {
+    param(
+        [string] $PreferredPath
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($PreferredPath)) {
+        if (-not (Test-Path -LiteralPath $PreferredPath -PathType Leaf)) {
+            throw "psign-tool was not found at '$PreferredPath'."
+        }
+
+        return (Get-Item -LiteralPath $PreferredPath).FullName
+    }
+
+    $command = Get-Command psign-tool -ErrorAction SilentlyContinue
+    if ($null -eq $command) {
+        throw "psign-tool is required for Azure Artifact Signing. Install Devolutions.Psign.Tool or download psign-tool from Devolutions/psign."
+    }
+
+    return $command.Source
+}
+
+function Invoke-PsignArtifactSign {
+    param(
+        [string] $ToolPath,
+        [string[]] $Files
+    )
+
+    $Files = @($Files | Where-Object { $_ -and (Test-Path -LiteralPath $_ -PathType Leaf) })
+    if ($Files.Count -eq 0) {
+        return
+    }
+
+    $metadataPath = Join-Path ([IO.Path]::GetTempPath()) ("artifact-signing-" + [guid]::NewGuid().ToString("N") + ".json")
+    $fileListPath = Join-Path ([IO.Path]::GetTempPath()) ("psign-files-" + [guid]::NewGuid().ToString("N") + ".txt")
+    try {
+        $metadata = [ordered]@{
+            Endpoint = $ArtifactSigningEndpoint
+            CodeSigningAccountName = $ArtifactSigningAccountName
+            CertificateProfileName = $ArtifactSigningProfileName
+        }
+        $metadata | ConvertTo-Json -Compress | Set-Content -LiteralPath $metadataPath -Encoding utf8
+        Set-Content -LiteralPath $fileListPath -Value $Files -Encoding utf8
+
+        & $ToolPath --mode portable --verbose sign `
+            --dmdf $metadataPath `
+            --artifact-signing-tenant-id $AzureTenantId `
+            --artifact-signing-client-id $ClientId `
+            --artifact-signing-client-secret $ClientSecret `
+            --timestamp-url $TimestampServer `
+            --timestamp-digest sha256 `
+            --digest sha256 `
+            --input-file-list $fileListPath
+        if ($LASTEXITCODE -ne 0) {
+            throw "psign-tool Artifact Signing failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $metadataPath, $fileListPath -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-LocalSign {
+    param(
+        [System.IO.FileInfo] $Package,
+        [string] $PlainTextPassword
+    )
+
+    $extension = $Package.Extension.ToLowerInvariant()
+    if ($extension -eq ".msi") {
+        if (-not (Get-Command signtool -ErrorAction SilentlyContinue)) {
+            throw "signtool.exe is required to sign MSI packages with a local certificate."
+        }
+
+        & signtool sign /fd SHA256 /td SHA256 /v /tr http://timestamp.digicert.com /n "Devolutions Inc." /a /f $CertificatePath /p $PlainTextPassword $Package.FullName
+        if ($LASTEXITCODE -ne 0) {
+            throw "Signing '$($Package.Name)' failed with exit code $LASTEXITCODE."
+        }
+
+        return
+    }
+
+    & winapp sign $Package.FullName $CertificatePath --password $PlainTextPassword
+    if ($LASTEXITCODE -ne 0) {
+        throw "Signing '$($Package.Name)' failed with exit code $LASTEXITCODE."
+    }
+}
+
+if ($useArtifactSigning) {
+    if ([string]::IsNullOrWhiteSpace($TimestampServer)) {
+        $TimestampServer = "http://timestamp.acs.microsoft.com/"
+    }
+
+    $PsignTool = Resolve-PsignTool -PreferredPath $PsignTool
+}
+else {
+    if ($null -eq $Password) {
+        $Password = Read-Host "Signing certificate password" -AsSecureString
+    }
+
+    $CertificatePath = [IO.Path]::GetFullPath($CertificatePath)
+    if (-not (Get-Command winapp -ErrorAction SilentlyContinue) -and -not (Get-Command signtool -ErrorAction SilentlyContinue)) {
+        throw "Local certificate signing requires either WinApp CLI or signtool on PATH."
+    }
+}
+
+$msixPackages = Get-ExpectedPackages -Names @(
     "Devolutions.Terminal_${Version}_x64.msix",
     "Devolutions.Terminal_${Version}_arm64.msix"
 )
-$packages = @(
-    foreach ($packageName in $expectedPackageNames) {
-        $packagePath = Join-Path $PackageDirectory $packageName
-        if (-not (Test-Path -LiteralPath $packagePath -PathType Leaf)) {
-            throw "Expected MSIX package '$packagePath' was not found."
-        }
-
-        Get-Item -LiteralPath $packagePath
-    }
+$msiPackages = Get-ExpectedPackages -Names @(
+    "Devolutions.Terminal_${Version}_x64.msi",
+    "Devolutions.Terminal_${Version}_arm64.msi"
 )
 
-if ($packages.Count -ne $expectedPackageNames.Count) {
-    throw "Signing requires the x64 and arm64 MSIX packages for version '$Version'."
+if ($msixPackages.Count -eq 0 -and $msiPackages.Count -eq 0) {
+    throw "No release packages for version '$Version' were found in '$PackageDirectory'."
 }
 
-$pointer = [Runtime.InteropServices.Marshal]::SecureStringToGlobalAllocUnicode($Password)
+$pointer = $null
+$plainTextPassword = $null
 try {
-    $plainTextPassword = [Runtime.InteropServices.Marshal]::PtrToStringUni($pointer)
-    foreach ($package in $packages) {
-        & winapp sign $package.FullName $CertificatePath --password $plainTextPassword
-        if ($LASTEXITCODE -ne 0) {
-            throw "Signing '$($package.Name)' failed with exit code $LASTEXITCODE."
+    if ($useArtifactSigning) {
+        $unsignedBundle = Join-Path $PackageDirectory "Devolutions.Terminal_${Version}_x64_arm64.msixbundle"
+        if (Test-Path -LiteralPath $unsignedBundle -PathType Leaf) {
+            Remove-Item -LiteralPath $unsignedBundle -Force
         }
+
+        $filesToSign = @()
+        if ($msixPackages.Count -gt 0) {
+            $filesToSign += @($msixPackages.FullName)
+        }
+        if ($msiPackages.Count -gt 0) {
+            $filesToSign += @($msiPackages.FullName)
+        }
+
+        Invoke-PsignArtifactSign -ToolPath $PsignTool -Files $filesToSign
+        return
     }
 
-    if ($packages.Count -gt 1) {
+    $pointer = [Runtime.InteropServices.Marshal]::SecureStringToGlobalAllocUnicode($Password)
+    $plainTextPassword = [Runtime.InteropServices.Marshal]::PtrToStringUni($pointer)
+
+    foreach ($package in $msixPackages) {
+        Invoke-LocalSign -Package $package -PlainTextPassword $plainTextPassword
+    }
+
+    if ($msixPackages.Count -gt 1) {
+        if (-not (Get-Command winapp -ErrorAction SilentlyContinue)) {
+            throw "WinApp CLI is required to rebuild the signed MSIX bundle."
+        }
+
         $bundleInput = Join-Path $PackageDirectory (".bundle-input-" + [guid]::NewGuid())
         New-Item -ItemType Directory -Path $bundleInput | Out-Null
         try {
-            Copy-Item -LiteralPath $packages.FullName -Destination $bundleInput
+            Copy-Item -LiteralPath $msixPackages.FullName -Destination $bundleInput
             $bundlePath = Join-Path $PackageDirectory "Devolutions.Terminal_${Version}_x64_arm64.msixbundle"
             & winapp tool makeappx bundle /d $bundleInput /p $bundlePath /bv $Version /o
             if ($LASTEXITCODE -ne 0) {
                 throw "Rebuilding the signed MSIX bundle failed with exit code $LASTEXITCODE."
             }
 
-            & winapp sign $bundlePath $CertificatePath --password $plainTextPassword
-            if ($LASTEXITCODE -ne 0) {
-                throw "Signing the MSIX bundle failed with exit code $LASTEXITCODE."
-            }
+            Invoke-LocalSign -Package (Get-Item -LiteralPath $bundlePath) -PlainTextPassword $plainTextPassword
         }
         finally {
             if (Test-Path -LiteralPath $bundleInput) {
@@ -75,8 +230,14 @@ try {
             }
         }
     }
+
+    foreach ($package in $msiPackages) {
+        Invoke-LocalSign -Package $package -PlainTextPassword $plainTextPassword
+    }
 }
 finally {
     $plainTextPassword = $null
-    [Runtime.InteropServices.Marshal]::ZeroFreeGlobalAllocUnicode($pointer)
+    if ($null -ne $pointer) {
+        [Runtime.InteropServices.Marshal]::ZeroFreeGlobalAllocUnicode($pointer)
+    }
 }

--- a/src/Devolutions.Terminal.Package/Scripts/Sign-Packages.ps1
+++ b/src/Devolutions.Terminal.Package/Scripts/Sign-Packages.ps1
@@ -183,11 +183,6 @@ $pointer = $null
 $plainTextPassword = $null
 try {
     if ($useArtifactSigning) {
-        $unsignedBundle = Join-Path $PackageDirectory "Devolutions.Terminal_${Version}_x64_arm64.msixbundle"
-        if (Test-Path -LiteralPath $unsignedBundle -PathType Leaf) {
-            Remove-Item -LiteralPath $unsignedBundle -Force
-        }
-
         $filesToSign = @()
         if ($msixPackages.Count -gt 0) {
             $filesToSign += @($msixPackages.FullName)
@@ -205,30 +200,6 @@ try {
 
     foreach ($package in $msixPackages) {
         Invoke-LocalSign -Package $package -PlainTextPassword $plainTextPassword
-    }
-
-    if ($msixPackages.Count -gt 1) {
-        if (-not (Get-Command winapp -ErrorAction SilentlyContinue)) {
-            throw "WinApp CLI is required to rebuild the signed MSIX bundle."
-        }
-
-        $bundleInput = Join-Path $PackageDirectory (".bundle-input-" + [guid]::NewGuid())
-        New-Item -ItemType Directory -Path $bundleInput | Out-Null
-        try {
-            Copy-Item -LiteralPath $msixPackages.FullName -Destination $bundleInput
-            $bundlePath = Join-Path $PackageDirectory "Devolutions.Terminal_${Version}_x64_arm64.msixbundle"
-            & winapp tool makeappx bundle /d $bundleInput /p $bundlePath /bv $Version /o
-            if ($LASTEXITCODE -ne 0) {
-                throw "Rebuilding the signed MSIX bundle failed with exit code $LASTEXITCODE."
-            }
-
-            Invoke-LocalSign -Package (Get-Item -LiteralPath $bundlePath) -PlainTextPassword $plainTextPassword
-        }
-        finally {
-            if (Test-Path -LiteralPath $bundleInput) {
-                Remove-Item -Recurse -Force -LiteralPath $bundleInput
-            }
-        }
     }
 
     foreach ($package in $msiPackages) {

--- a/src/Devolutions.Terminal.Package/Scripts/Test-Packages.ps1
+++ b/src/Devolutions.Terminal.Package/Scripts/Test-Packages.ps1
@@ -203,31 +203,7 @@ begin {
 process {
     foreach ($path in $PackagePath) {
         $resolvedPath = [IO.Path]::GetFullPath($path)
-        if ([IO.Path]::GetExtension($resolvedPath) -eq ".msixbundle") {
-            if ($RequireSignature) {
-                Test-Signature $resolvedPath
-            }
-
-            $bundlePath = Join-Path ([IO.Path]::GetTempPath()) ("wt-msixbundle-" + [guid]::NewGuid())
-            New-Item -ItemType Directory -Path $bundlePath | Out-Null
-            try {
-                Invoke-MakeAppx -Arguments @("unbundle", "/p", $resolvedPath, "/d", $bundlePath, "/o")
-                $bundledPackages = @(Get-ChildItem -LiteralPath $bundlePath -Filter "*.msix" -File)
-                Assert-Condition ($bundledPackages.Count -eq 2) "The bundle must contain exactly x64 and arm64 packages."
-                $results = @($bundledPackages | ForEach-Object { Test-Msix $_.FullName })
-                $architectures = @($results.Architecture | Sort-Object -Unique)
-                Assert-Condition (
-                    $architectures.Count -eq 2 -and
-                    $architectures -contains "x64" -and
-                    $architectures -contains "arm64"
-                ) "The bundle does not contain both x64 and arm64 packages."
-                $results
-            }
-            finally {
-                Remove-Item -Recurse -Force -LiteralPath $bundlePath
-            }
-        }
-        elseif ([IO.Path]::GetExtension($resolvedPath) -eq ".msix") {
+        if ([IO.Path]::GetExtension($resolvedPath) -eq ".msix") {
             Test-Msix $resolvedPath
         }
         else {

--- a/src/Devolutions.Terminal.Package/Scripts/Write-MsiComponents.ps1
+++ b/src/Devolutions.Terminal.Package/Scripts/Write-MsiComponents.ps1
@@ -1,0 +1,145 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $PublishDir,
+
+    [Parameter(Mandatory = $true)]
+    [string] $OutputFile
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$publishRoot = [IO.Path]::GetFullPath($PublishDir)
+if (-not (Test-Path -LiteralPath $publishRoot -PathType Container)) {
+    throw "Publish directory '$publishRoot' does not exist."
+}
+
+$directoryIds = @{}
+$files = Get-ChildItem -LiteralPath $publishRoot -File -Recurse |
+    Where-Object { $_.Extension -ne ".pdb" } |
+    Sort-Object FullName
+
+function Get-ParentPath {
+    param([string] $Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or $Path -eq '.') {
+        return ''
+    }
+
+    $normalized = $Path.Replace('\\', '/')
+    $index = $normalized.LastIndexOf('/')
+    if ($index -lt 0) {
+        return ''
+    }
+
+    return $normalized.Substring(0, $index)
+}
+
+function Get-RelativePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $BasePath,
+
+        [Parameter(Mandatory = $true)]
+        [string] $TargetPath
+    )
+
+    $baseFull = [IO.Path]::GetFullPath($BasePath).TrimEnd('\')
+    $targetFull = [IO.Path]::GetFullPath($TargetPath)
+
+    if ($targetFull.StartsWith($baseFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $relative = $targetFull.Substring($baseFull.Length).TrimStart('\\', '/')
+        if ([string]::IsNullOrWhiteSpace($relative)) {
+            return '.'
+        }
+
+        return $relative.Replace('\\', '/')
+    }
+
+    $baseUri = [Uri]::new(($baseFull + [IO.Path]::DirectorySeparatorChar))
+    $targetUri = [Uri]::new($targetFull)
+    $relative = [Uri]::UnescapeDataString($baseUri.MakeRelativeUri($targetUri).ToString())
+    return $relative.Replace('\\', '/')
+}
+
+foreach ($file in $files) {
+    $relativeDirectory = Get-RelativePath -BasePath $publishRoot -TargetPath ([IO.Path]::GetDirectoryName($file.FullName))
+    if ([string]::IsNullOrWhiteSpace($relativeDirectory) -or $relativeDirectory -eq '.' -or $relativeDirectory -eq './') {
+        continue
+    }
+
+    $path = $relativeDirectory
+    while (-not [string]::IsNullOrWhiteSpace($path)) {
+        if (-not $directoryIds.ContainsKey($path)) {
+            $directoryIds[$path] = 'DIR_' + (($path -replace '[^A-Za-z0-9_]', '_').Trim('_'))
+        }
+
+        $parent = Get-ParentPath $path
+        if ([string]::IsNullOrWhiteSpace($parent) -or $parent -eq $path) {
+            break
+        }
+
+        $path = $parent
+    }
+}
+
+function EmitDirectories {
+    param(
+        [string] $ParentPath,
+        [System.Text.StringBuilder] $Builder
+    )
+
+    $children = @($directoryIds.Keys | Where-Object {
+        $parent = Get-ParentPath $_
+        $parent -eq $ParentPath
+    } | Sort-Object)
+
+    foreach ($child in $children) {
+        $directoryId = $directoryIds[$child]
+        $directoryName = [IO.Path]::GetFileName($child)
+        [void]$Builder.AppendLine("      <Directory Id='$directoryId' Name='$directoryName'>")
+        EmitDirectories -ParentPath $child -Builder $Builder
+        [void]$Builder.AppendLine("      </Directory>")
+    }
+}
+
+$builder = [System.Text.StringBuilder]::new()
+[void]$builder.AppendLine('<?xml version="1.0" encoding="utf-8"?>')
+[void]$builder.AppendLine('<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">')
+[void]$builder.AppendLine('  <Fragment>')
+[void]$builder.AppendLine('    <DirectoryRef Id="INSTALLLOCATION">')
+EmitDirectories -ParentPath '' -Builder $builder
+[void]$builder.AppendLine('    </DirectoryRef>')
+[void]$builder.AppendLine('    <ComponentGroup Id="ProductComponents">')
+
+foreach ($file in $files) {
+    $relativePath = Get-RelativePath -BasePath $publishRoot -TargetPath $file.FullName
+    $relativeDirectory = [IO.Path]::GetDirectoryName($relativePath)
+    if ([string]::IsNullOrWhiteSpace($relativeDirectory) -or $relativeDirectory -eq '.' -or $relativeDirectory -eq './') {
+        $directoryId = 'INSTALLLOCATION'
+    }
+    else {
+        $directoryId = $directoryIds[$relativeDirectory.Replace('\\', '/')]
+    }
+
+    $componentId = 'cmp_' + (($relativePath -replace '[^A-Za-z0-9_]', '_').Trim('_'))
+    if ([string]::IsNullOrWhiteSpace($componentId)) {
+        $componentId = 'cmp_' + [guid]::NewGuid().ToString('N')
+    }
+
+    [void]$builder.AppendLine("      <Component Directory='$directoryId'>")
+    [void]$builder.AppendLine("        <File Id='$componentId' Source='$([System.Security.SecurityElement]::Escape($file.FullName))' KeyPath='yes' />")
+    [void]$builder.AppendLine('      </Component>')
+}
+
+[void]$builder.AppendLine('    </ComponentGroup>')
+[void]$builder.AppendLine('  </Fragment>')
+[void]$builder.AppendLine('</Wix>')
+
+$directory = Split-Path -Parent $OutputFile
+if (-not [string]::IsNullOrWhiteSpace($directory)) {
+    New-Item -ItemType Directory -Force -Path $directory | Out-Null
+}
+
+[IO.File]::WriteAllText($OutputFile, $builder.ToString(), [Text.UTF8Encoding]::new($false))

--- a/src/Devolutions.Terminal.Package/Scripts/Write-MsiComponents.ps1
+++ b/src/Devolutions.Terminal.Package/Scripts/Write-MsiComponents.ps1
@@ -49,7 +49,7 @@ function Get-RelativePath {
     $targetFull = [IO.Path]::GetFullPath($TargetPath)
 
     if ($targetFull.StartsWith($baseFull, [System.StringComparison]::OrdinalIgnoreCase)) {
-        $relative = $targetFull.Substring($baseFull.Length).TrimStart('\\', '/')
+        $relative = $targetFull.Substring($baseFull.Length).TrimStart('\', '/')
         if ([string]::IsNullOrWhiteSpace($relative)) {
             return '.'
         }


### PR DESCRIPTION
## Summary

Adds a release-only packaging and publishing path for Devolutions Terminal. Regular CI still builds and tests unsigned artifacts; publication happens only on tag or manual dispatch, and assets go straight to GitHub Releases (no OneDrive).

## What this includes

- Release-only workflow job gated on `workflow_dispatch` or `v*` tags
- Windows x64/ARM64 **MSIX** packages (`Devolutions.Terminal_<version>_x64.msix` and `_arm64.msix`) plus a WiX **MSI** installer
- Linux x64/ARM64 and macOS ARM64 package artifacts
- Windows signing on the Linux release runner with Devolutions [`psign-tool`](https://github.com/Devolutions/psign) and **Azure Artifact Signing** (Trusted Signing)
- Direct `gh release` upload of signed Windows packages and Linux/macOS archives

## Signing model

The private key never lands on the runner. CI downloads `psign-tool` from `Devolutions/psign` and signs per-architecture `.msix` and `.msi` files in place:

```text
psign-tool --mode portable sign --dmdf <metadata.json> ...
```

Required secrets:

- `ARTIFACT_SIGNING_ENDPOINT`
- `ARTIFACT_SIGNING_ACCOUNT_NAME`
- `ARTIFACT_SIGNING_PROFILE_NAME`
- `AZURE_TENANT_ID`
- `CODE_SIGNING_CLIENT_ID`
- `CODE_SIGNING_CLIENT_SECRET`

Optional variable:

- `CODE_SIGNING_TIMESTAMP_SERVER` (defaults to `http://timestamp.acs.microsoft.com/`)

Local PFX signing remains available for development dry-runs only.

## Notes

- Windows MSIX output is per-architecture only. No `.msixbundle` is built or published.
- The MSIX `Publisher` in `Package.appxmanifest` must match the Artifact Signing certificate subject.
- PR and branch builds stay unsigned and non-publishing.

## Validation

- Downloaded CI artifacts from a successful PR build and validated the unsigned Windows MSIX packages, Linux SHA-256 manifests, and macOS app zip layout.